### PR TITLE
Add ability to tag models as "beta"

### DIFF
--- a/src/habitat_mapper/config.py
+++ b/src/habitat_mapper/config.py
@@ -29,6 +29,7 @@ class ModelConfig(BaseModel):
     name: Annotated[str, "The name of the model for the model registry"]
     description: Annotated[str | None, "Brief description of the model for the model registry"] = None
     revision: Annotated[str, "Model revision number. Date based versioning is preferred"]
+    beta: bool = False
     dependencies: Annotated[
         list[str],
         "List of files to download (URLs or local paths). Downloaded to model-specific cache subdirectory.",

--- a/src/habitat_mapper/main.py
+++ b/src/habitat_mapper/main.py
@@ -135,6 +135,7 @@ def models() -> None:
             latest_revision = model_registry.get_latest_revision(model_name)
             model = model_registry[model_name]  # Gets latest revision
             cfg = model.cfg
+            is_beta = cfg.beta
 
             # Check if model is cached locally
             # Check if any dependency is a URL
@@ -149,7 +150,7 @@ def models() -> None:
                 status = "[green]Local[/green]"
 
             table.add_row(
-                model_name,
+                f"{model_name}{' [i][red](beta)[/red][/i]' if is_beta else ''}",
                 latest_revision,
                 cfg.description or "No description",
                 status,


### PR DESCRIPTION
Allow tagging model as "beta" to denote that it they are pre-production and may change. Beta models have no guarantees for support in future releases
